### PR TITLE
Split the database credentials into multiple functions

### DIFF
--- a/resources/library.php
+++ b/resources/library.php
@@ -29,19 +29,37 @@ function add_migration($m)
     $db->query("insert into migrations set filename='$m'");
 }
 
+function connectDocker()
+{
+    return [getenv("MYSQL_HOST"),"root","root","luxemanagers",3306];
+}
+
+function connectAntimatterServer()
+{
+    return ["localhost","luxemanagers","j4z132gs63c0y8hr","luxemanagers",3306];
+}
+
+function connectMAMP()
+{
+    return ["localhost","root","root","luxemanagers",3306];
+}
+
 // Creates a database connections
 function connect()
 {
-    // On docker, we need to use the environment variable
-    // On MAMP, we need to use localhost, so this line of code decides between both options automatically
-    $hostname = getenv("MYSQL_HOST") ?: "localhost";
-    $username = "root";
-    $password = "root";
-    $database = "luxemanagers";
-    $dbport = 3306;
-    
+    // We have to detect where our code is running, so we can use the right database details
+    // The database on your MAMP laptop setup is different from my docker setup and my antimatter server setup
+    if(getenv("MYSQL_HOST")){
+        // Jenna, ask me what this list does and I will explain, it looks far more complicated then it is in reality
+        list($hostname,$username,$password,$database,$port) = connectDocker();
+    }else if(strpos(__DIR__,"clients.antimatter-studios.com") !== false) {
+        list($hostname,$username,$password,$database,$port) = connectAntimatterServer();
+    }else {
+        list($hostname,$username,$password,$database,$port) = connectMAMP();
+    }
+
     // Create connection
-    $db = new mysqli($hostname, $username, $password, $database, $dbport);
+    $db = new mysqli($hostname, $username, $password, $database, $port);
     
     // Check connection
     if ($db->connect_error) {


### PR DESCRIPTION
I needed to do this so that Docker, MAMP, and the Antimatter server could all connect to the database, but using various different credentials.

You can see that I create an if statement, each with its own set of conditions in order to recognise where the code is running.

the list() function is new to you, but what it does is quite fascinating and very useful, what you can do is this, which is what I am doing, at its very basis.

    list($hostname,$username,$password,$database,$port) = [ 
        "localhost",
        "yakotta",
        "password",
        "luxemanagers",
        3306
    ];

Which isn't so hard, but what the list() function in this circumstance does, is that each variable you see as the next parameter to list, is given the value from the corresponding element in the array on the right.

So the first parameter, $hostname, is given the value "localhost", $username, is given the value "yakotta"

So its useful, when wanting to split up an array, into discrete variables.

You might ask, why would I want to do this, why not just use $array[0] which is what the hostname is, the value "localhost", but this is quite opaque and not intuitive, right? does $array[0] mean "hostname" to you? I mean, looking at the code, then yes, it makes sense, but is it obvious?

So what about just using list to split up the array like this and then using $hostname instead? Isnt that easier?

There are many ways you can use this functionality, it really depends on your circumstances, many of them make code easier to understand, you will use this functionality in the future, so I wanted to explain it in greater detail