### PR TITLE
the database migrations had filenames which reflected the local compu…

### DIFF
--- a/resources/library.php
+++ b/resources/library.php
@@ -12,6 +12,9 @@ function var_dump_pre ($input_variable)
 function check_migration($m)
 {
     $db = connect();
+
+    $m = str_replace($_SERVER["DOCUMENT_ROOT"], "", $m);
+
     $result = $db->query("select filename from migrations where filename = '$m'");
 
     if($result === false) return false;
@@ -25,6 +28,8 @@ function check_migration($m)
 function add_migration($m)
 {
     $db = connect();
+
+    $m = str_replace($_SERVER["DOCUMENT_ROOT"], "", $m);
     
     $db->query("insert into migrations set filename='$m'");
 }


### PR DESCRIPTION
…ter they ran on, so jennas migrations had her username in them and when ran on my computer, those filenames were different, so it would attempt to run the migrations again, even though they had already run, so I trim the document root from the filenames now, so they are generic on all computers, shouldnt continue to have this problem anymore